### PR TITLE
fix: add Java 25 support for Spigot version 26.1

### DIFF
--- a/.github/create_javadocs_jar_file.py
+++ b/.github/create_javadocs_jar_file.py
@@ -25,6 +25,7 @@ JAVA_PATHS = {
     18: Path(os.getenv("JAVA_HOME_18_X64", "/usr/lib/jvm/java-18-openjdk-amd64")),
     19: Path(os.getenv("JAVA_HOME_19_X64", "/usr/lib/jvm/java-19-openjdk-amd64")),
     21: Path(os.getenv("JAVA_HOME_21_X64", "/usr/lib/jvm/java-21-openjdk-amd64")),
+    25: Path(os.getenv("JAVA_HOME_25_X64", "/usr/lib/jvm/java-25-openjdk-amd64")),
 }
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,7 @@ jobs:
             18
             19
             21
+            25
 
       - name: Install Python dependencies
         run: |


### PR DESCRIPTION
## Summary
- Spigot version 26.1 requires Java 25-26 (class versions 69-70), but the CI only installed up to Java 21
- Adds Java 25 (Temurin) to the GitHub Actions workflow JDK setup
- Adds Java 25 path mapping to the Python build script

## Root Cause
The build failed with: `No suitable Java version found for range 25-26`

## Test plan
- [ ] Verify the Build workflow passes on this branch
- [ ] Confirm Java 25 is properly installed via Temurin in CI